### PR TITLE
docs: add infra-as-code to minimal project structure

### DIFF
--- a/.azuredevops/README.md
+++ b/.azuredevops/README.md
@@ -1,0 +1,8 @@
+# `/.azuredevops`
+
+ YAML pipelines, pull request templates for Azure DevOps;
+
+- `pipelines/`
+  - `variables/`
+  - `jobs/`
+  - `steps/`

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -1,0 +1,3 @@
+# `/deployments`
+
+Docker compose, terraform, helm scripts, and configuration files.


### PR DESCRIPTION
this changeset is to update the default project structure where infra-as-code supported.