### PR TITLE
chore: install copilot extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -63,6 +63,10 @@
         "ms-mssql.mssql",
         "humao.rest-client",
 
+        "GitHub.copilot",
+        "GitHub.copilot-chat",
+        "ms-azuretools.vscode-azure-github-copilot",
+
         "redhat.vscode-yaml",
         "editorconfig.editorconfig",
         "albert.tabout",


### PR DESCRIPTION
this changes is to install github copilot related vs code extensions.

- install github copilot extensions
- install github copilot for azure