### PR TITLE
fix: switch to opentofu from terraform and terragrunt tools

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,11 +34,7 @@
     },
 
     // Read more https://github.com/hashicorp/vscode-terraform/issues/1524#issuecomment-1614892272
-    "ghcr.io/devcontainers/features/terraform:1": {
-      "version": "latest",
-      "tflint": "latest",
-      "terragrunt": "latest"
-    }
+    "ghcr.io/alertbox/devcontainer-features/opentofu:1": {}
   },
   "containerEnv": {
     // Set dotnet CLI environment settings.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "ms-azuretools.vscode-docker",
+    "ms-azuretools.vscode-containers",
     "ms-vscode-remote.remote-containers",
   ],
 }


### PR DESCRIPTION
this changeset is to replace terraform tools from opentofu.

- remove terraform and terragrunt
- add opentofu
- remove docker extension
- add containers extension 
